### PR TITLE
#9: on iOS the bounce effect is not correctly removed (closes #9)

### DIFF
--- a/fullscreenApp.css
+++ b/fullscreenApp.css
@@ -1,8 +1,15 @@
-html {
-  overflow: hidden;
-}
-
+/*Set main wrappers to have window's height and width*/
 html, body, #app {
   height: 100%;
   width: 100%;
+}
+
+/*Remove bounce back effect on OSX, Safari (desktop and iOS)*/
+html {
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 }


### PR DESCRIPTION
Closes #9

## Test Plan

### tests performed
- tested on AlinityPRO on an iPad
- the main page wrapper doesn't bounce anymore 🌮 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
